### PR TITLE
Remover atributos de request do método APIResource::createAPI

### DIFF
--- a/lib/Iugu/APIResource.php
+++ b/lib/Iugu/APIResource.php
@@ -80,9 +80,6 @@ class APIResource extends Iugu_Object
                 'POST', static::url($attributes), $attributes
             )
         );
-        foreach ($attributes as $attr => $value) {
-            $response[$attr] = $value;
-        }
 
         return $response;
     }


### PR DESCRIPTION
Sugiro a remoção dos atibutos da requisição no método `APIResource::createAPI`, pois os atributos causam override na resposta da API, o que pode levar em perda de dados da resposta.

Exemplo:

Atributo da lista de itens na requisição:

```php
[
    'description' => 'Produto Teste',
    'price_cents' => 100,
    'quantity' => 1
]
```

Como a resposta vem da API:

```php
[
    'id' => '11DA8B1662EC4C30BC4C78AEDC619145',
    'description' => 'Produto Teste',
    'price_cents' => 100,
    'quantity' => 1,
    'created_at' => '2014-06-17T09:58:05-03:00',
    'updated_at' => '2014-06-17T09:58:05-03:00',
    'price' => 'R$ 10,00'
]
```

Porém, ao aplicar o código

```php
foreach ($attributes as $attr => $value) {
    $response[$attr] = $value;
}
```

Basicamente causa override pelas chaves de request e response serem as mesmas, e com isso você perde dados da resposta.
Não há necessidade alguma de incluir os atributos de request na resposta.